### PR TITLE
Update to use transmission library (OSK-5)

### DIFF
--- a/src/OSK.MessageBus.Local.UnitTests/Helpers/TestMessage.cs
+++ b/src/OSK.MessageBus.Local.UnitTests/Helpers/TestMessage.cs
@@ -1,4 +1,4 @@
-﻿using OSK.MessageBus.Messages.Abstractions;
+﻿using OSK.Transmissions.Messages.Abstractions;
 
 namespace OSK.MessageBus.Local.UnitTests.Helpers
 {

--- a/src/OSK.MessageBus.Local.UnitTests/Internal/Services/LocalMessageTransmitterTests.cs
+++ b/src/OSK.MessageBus.Local.UnitTests/Internal/Services/LocalMessageTransmitterTests.cs
@@ -1,10 +1,10 @@
 ﻿using Moq;
-using OSK.MessageBus.Abstractions;
 using OSK.MessageBus.Local.Internal.Services;
 using OSK.MessageBus.Local.Models;
 using OSK.MessageBus.Local.Options;
 using OSK.MessageBus.Local.Ports;
 using OSK.MessageBus.Local.UnitTests.Helpers;
+using OSK.Transmissions.Abstractions;
 using Xunit;
 
 namespace OSK.MessageBus.Local.UnitTests.Internal.Services

--- a/src/OSK.MessageBus.Local/Internal/Services/LocalMessageBus.cs
+++ b/src/OSK.MessageBus.Local/Internal/Services/LocalMessageBus.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using OSK.MessageBus.Application;
 using OSK.MessageBus.Local.Options;
 using OSK.MessageBus.Local.Ports;
-using OSK.MessageBus.Ports;
+using OSK.Transmissions.Application;
+using OSK.Transmissions.Ports;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OSK.MessageBus.Local/Internal/Services/LocalMessageBusBuilder.cs
+++ b/src/OSK.MessageBus.Local/Internal/Services/LocalMessageBusBuilder.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using OSK.MessageBus.Abstractions;
 using OSK.MessageBus.Local.Options;
 using OSK.MessageBus.Local.Ports;
-using OSK.MessageBus.Messages.Abstractions;
-using OSK.MessageBus.Options;
-using OSK.MessageBus.Ports;
+using OSK.Transmissions;
+using OSK.Transmissions.Abstractions;
+using OSK.Transmissions.Messages.Abstractions;
+using OSK.Transmissions.Ports;
 
 namespace OSK.MessageBus.Local.Internal.Services
 {
@@ -29,7 +29,7 @@ namespace OSK.MessageBus.Local.Internal.Services
         {
             _receiverConfigurations.Add(transmissionBuilder =>
             {
-                transmissionBuilder.AddMessageEventReceiver<LocalMessageEventReceiver<TMessage>>(
+                transmissionBuilder.AddMessageReceiver<LocalMessageReceiver<TMessage>>(
                     Guid.NewGuid().ToString(), [topicFilter], receiverBuilder =>
                     {
                         receiverBuilder.UseHandler(handler);
@@ -46,7 +46,7 @@ namespace OSK.MessageBus.Local.Internal.Services
         {
             _receiverConfigurations.Add(transmissionBuilder =>
             {
-                transmissionBuilder.AddMessageEventReceiver<LocalMessageEventReceiver<TMessage>>(
+                transmissionBuilder.AddMessageReceiver<LocalMessageReceiver<TMessage>>(
                     Guid.NewGuid().ToString(), [topicFilter], receiverBuilder =>
                     {
                         receiverBuilder.UseHandler<TMessage, THandler>();

--- a/src/OSK.MessageBus.Local/Internal/Services/LocalMessageReceiver.cs
+++ b/src/OSK.MessageBus.Local/Internal/Services/LocalMessageReceiver.cs
@@ -1,15 +1,16 @@
 ﻿using OSK.MessageBus.Local.Ports;
 using System;
 using System.Threading.Tasks;
-using OSK.MessageBus.Models;
 using OSK.MessageBus.Local.Models;
-using OSK.MessageBus.Messages.Abstractions;
+using OSK.Transmissions;
+using OSK.Transmissions.Messages.Abstractions;
+using OSK.Transmissions.Models;
 
 namespace OSK.MessageBus.Local.Internal.Services
 {
-    internal class LocalMessageEventReceiver<TMessage>(string receiverId, string topicId, MessageTransmissionDelegate transmissionDelegate,
+    internal class LocalMessageReceiver<TMessage>(string receiverId, string topicId, MessageTransmissionDelegate transmissionDelegate,
         ILocalMessageTransmitter transmitter, IServiceProvider serviceProvider)
-        : MessageEventReceiverBase(receiverId, transmissionDelegate, serviceProvider), ILocalMessageReceiver
+        : MessageReceiverBase(receiverId, transmissionDelegate, serviceProvider), ILocalMessageReceiver
         where TMessage : IMessage
     {
         #region ILocalMessageEventReceiver

--- a/src/OSK.MessageBus.Local/Internal/Services/LocalMessageTransmitter.cs
+++ b/src/OSK.MessageBus.Local/Internal/Services/LocalMessageTransmitter.cs
@@ -1,8 +1,8 @@
-﻿using OSK.MessageBus.Abstractions;
-using OSK.MessageBus.Local.Models;
+﻿using OSK.MessageBus.Local.Models;
 using OSK.MessageBus.Local.Options;
 using OSK.MessageBus.Local.Ports;
-using OSK.MessageBus.Messages.Abstractions;
+using OSK.Transmissions.Abstractions;
+using OSK.Transmissions.Messages.Abstractions;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/OSK.MessageBus.Local/LocalMessageBusBuilderExtensions.cs
+++ b/src/OSK.MessageBus.Local/LocalMessageBusBuilderExtensions.cs
@@ -1,9 +1,9 @@
-﻿using OSK.MessageBus.Abstractions;
-using OSK.MessageBus.Ports;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System;
 using OSK.MessageBus.Local.Ports;
-using OSK.MessageBus.Messages.Abstractions;
+using OSK.Transmissions.Abstractions;
+using OSK.Transmissions.Messages.Abstractions;
+using OSK.Transmissions.Ports;
 
 namespace OSK.MessageBus.Local
 {

--- a/src/OSK.MessageBus.Local/Models/LocalMessage.cs
+++ b/src/OSK.MessageBus.Local/Models/LocalMessage.cs
@@ -1,4 +1,4 @@
-﻿using OSK.MessageBus.Messages.Abstractions;
+﻿using OSK.Transmissions.Messages.Abstractions;
 using System;
 
 namespace OSK.MessageBus.Local.Models

--- a/src/OSK.MessageBus.Local/OSK.MessageBus.Local.csproj
+++ b/src/OSK.MessageBus.Local/OSK.MessageBus.Local.csproj
@@ -22,8 +22,8 @@
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-		<PackageReference Include="OSK.MessageBus.Application" Version="0.2.0" />
-		<PackageReference Include="OSK.MessageBus" Version="0.2.0" />
+		<PackageReference Include="OSK.Transmissions.Application" Version="0.3.0" />
+		<PackageReference Include="OSK.Transmissions" Version="0.3.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.MessageBus.Local/Ports/ILocalMessageBusBuilder.cs
+++ b/src/OSK.MessageBus.Local/Ports/ILocalMessageBusBuilder.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using OSK.MessageBus.Abstractions;
 using System.Threading.Tasks;
 using OSK.MessageBus.Local.Options;
-using OSK.MessageBus.Ports;
-using OSK.MessageBus.Messages.Abstractions;
 using OSK.Hexagonal.MetaData;
+using OSK.Transmissions.Ports;
+using OSK.Transmissions.Abstractions;
+using OSK.Transmissions.Messages.Abstractions;
 
 namespace OSK.MessageBus.Local.Ports
 {

--- a/src/OSK.MessageBus.Local/Ports/ILocalMessageReceiver.cs
+++ b/src/OSK.MessageBus.Local/Ports/ILocalMessageReceiver.cs
@@ -1,6 +1,6 @@
 ﻿using OSK.Hexagonal.MetaData;
 using OSK.MessageBus.Local.Models;
-using OSK.MessageBus.Ports;
+using OSK.Transmissions.Ports;
 using System.Threading.Tasks;
 
 namespace OSK.MessageBus.Local.Ports

--- a/src/OSK.MessageBus.Local/Ports/ILocalMessageTransmitter.cs
+++ b/src/OSK.MessageBus.Local/Ports/ILocalMessageTransmitter.cs
@@ -1,6 +1,6 @@
 ﻿using OSK.Hexagonal.MetaData;
-using OSK.MessageBus.Abstractions;
 using OSK.MessageBus.Local.Options;
+using OSK.Transmissions.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/OSK.MessageBus.Local/ServiceCollectionExtensions.cs
+++ b/src/OSK.MessageBus.Local/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using OSK.MessageBus.Local.Internal.Services;
 using OSK.MessageBus.Local.Ports;
+using OSK.Transmissions;
 using System;
 
 namespace OSK.MessageBus.Local
@@ -9,7 +10,7 @@ namespace OSK.MessageBus.Local
     {
         public static IServiceCollection AddLocalBus(this IServiceCollection services, Action<ILocalMessageBusBuilder> localBusConfigurator)
         {
-            services.AddMessageEventTransmitter<LocalMessageTransmitter, ILocalMessageReceiver>("OSK.MessageBus.Local", builder =>
+            services.AddMessageTransmitter<LocalMessageTransmitter, ILocalMessageReceiver>("OSK.MessageBus.Local", builder =>
             {
                 var localMessageBusBuilder = new LocalMessageBusBuilder(services, builder);
                 localBusConfigurator(localMessageBusBuilder);


### PR DESCRIPTION
Motivation
----
Recent domain name has been changed for the underlying message delivery mechanism.

Modifications
----
* Updating entire project for latest domain name changes

Result
----
Project is up to date with core delivery mechanism

Fixes #5